### PR TITLE
Fix Gemini model settings usage

### DIFF
--- a/src/utils/modelUtils.js
+++ b/src/utils/modelUtils.js
@@ -20,12 +20,22 @@ class BaseModelHandler {
 class GeminiHandler extends BaseModelHandler {
   constructor(config) {
     super(config);
-    this.model = new GoogleGenerativeAI(config.apiKey).getGenerativeModel({ model: 'gemini-pro' });
+    this.modelSettings = config.modelSettings || {};
+    const modelName = this.modelSettings.model || 'gemini-pro';
+    this.model = new GoogleGenerativeAI(config.apiKey).getGenerativeModel({ model: modelName });
   }
 
   async generateContent(prompt) {
     try {
-      const result = await this.model.generateContent(prompt);
+      const generationConfig = {};
+      if (this.modelSettings.maxTokens) {
+        generationConfig.maxOutputTokens = this.modelSettings.maxTokens;
+      }
+      if (typeof this.modelSettings.temperature === 'number') {
+        generationConfig.temperature = this.modelSettings.temperature;
+      }
+
+      const result = await this.model.generateContent(prompt, { generationConfig });
       return result;
     } catch (error) {
       console.error('Gemini API error:', error.message);

--- a/tests/unit/utils/modelUtils.test.js
+++ b/tests/unit/utils/modelUtils.test.js
@@ -1,25 +1,26 @@
 // Mock external dependencies before imports
+
 jest.mock('@google/generative-ai', () => {
   const mockGenerateContent = jest.fn().mockResolvedValue({
     response: {
       text: () => '{"test": {"word": "test", "meanings": [{"speech_part": "noun"}], "phonetics": [{"type": "US"}]}}'
     }
   });
-  
-  const mockGenerateContentRateLimited = jest.fn().mockRejectedValue(new Error('API rate limit exceeded'));
-  
-  return {
-    GoogleGenerativeAI: jest.fn().mockImplementation(() => ({
-      getGenerativeModel: jest.fn().mockReturnValue({
-        // Return a function that can be override in specific tests
-        generateContent: mockGenerateContent
-      })
-    })),
-    mockGenerateContent,
-    mockGenerateContentRateLimited
-  };
-}), { virtual: true };
 
+  const mockGenerateContentRateLimited = jest.fn().mockRejectedValue(new Error('API rate limit exceeded'));
+  const mockGetGenerativeModel = jest.fn().mockReturnValue({ generateContent: mockGenerateContent });
+  const mockGoogleGenerativeAI = jest.fn().mockImplementation(() => ({
+    getGenerativeModel: mockGetGenerativeModel
+  }));
+
+  return {
+    GoogleGenerativeAI: mockGoogleGenerativeAI,
+    mockGenerateContent,
+    mockGenerateContentRateLimited,
+    mockGetGenerativeModel,
+    mockGoogleGenerativeAI
+  };
+}, { virtual: true });
 jest.mock('openai', () => {
   const mockCreate = jest.fn().mockResolvedValue({
     choices: [
@@ -116,6 +117,28 @@ describe('GeminiHandler', () => {
 
     const handler = new GeminiHandler(config);
     await expect(handler.generateContent('test')).rejects.toThrow('API rate limit exceeded');
+  });
+
+  test('uses provided model settings when calling API', async () => {
+    const customConfig = {
+      apiKey: 'custom-key',
+      modelSettings: { model: 'gemini-flash', maxTokens: 500, temperature: 0.5 }
+    };
+    const handler = new GeminiHandler(customConfig);
+
+    await handler.generateContent('prompt');
+
+    const {
+      mockGoogleGenerativeAI,
+      mockGetGenerativeModel,
+      mockGenerateContent
+    } = require('@google/generative-ai');
+
+    expect(mockGoogleGenerativeAI).toHaveBeenCalledWith('custom-key');
+    expect(mockGetGenerativeModel).toHaveBeenCalledWith({ model: 'gemini-flash' });
+    expect(mockGenerateContent).toHaveBeenCalledWith('prompt', {
+      generationConfig: { maxOutputTokens: 500, temperature: 0.5 }
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- support custom model settings in GeminiHandler
- test GeminiHandler with custom settings

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bdeefc5d483238711dd9457b14f44